### PR TITLE
General cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - project folder containing `dartino.yaml` is analyzed as Dartino project
 - auto save editors before running on device
 - menu actions for 'Getting Started' and 'SDK Docs'
+- auto close/cleanup compile/launch dialogs
 
 ## 0.0.3
 - add support to compile, deploy, run Dartino app on STM32 Discovery board from Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dartino plugin changelog
 
+## unreleased
+- project folder containing `dartino.yaml` is analyzed as Dartino project
+- auto save editors before running on device
+- menu actions for 'Getting Started' and 'SDK Docs'
+
 ## 0.0.3
 - add support to compile, deploy, run Dartino app on STM32 Discovery board from Linux
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 [![Build Status](https://travis-ci.org/dartino/atom-dartino.svg?branch=master)](https://travis-ci.org/dartino/atom-dartino)
 
-This package is a [SoD](https://github.com/domokit/sod) development plugin
+This package is a [Dartino](http://dartino.github.io/sdk/)
+and [SoD](https://github.com/domokit/sod) development plugin
 for [Atom](https://atom.io)
 built on top of the Atom [dartlang](https://atom.io/packages/dartlang) plugin.
-
-[Dartino](http://dartino.github.io/sdk/) support in the works.
 
 ## Features
 

--- a/lib/dartino.dart
+++ b/lib/dartino.dart
@@ -7,6 +7,7 @@ library atom.dartino.plugin;
 import 'dart:async';
 
 import 'package:atom/atom.dart';
+import 'package:atom/node/fs.dart';
 import 'package:atom/node/process.dart';
 import 'package:atom/node/shell.dart';
 import 'package:atom/utils/disposable.dart';
@@ -177,11 +178,11 @@ _runAppOnDevice(event) async {
 
   // Deploy and run the app on the device
   if (await sdk.deployAndRun(portName, dstPath)) {
-    atom.notifications.addInfo('Launched app on device', dismissable: true);
+    atom.notifications.addInfo('Launched app on device');
   }
 }
 
-_showGettingStarted(event) async {
+_showGettingStarted(event) {
   shell.openExternal('https://dartino.org/index.html');
 }
 
@@ -189,5 +190,6 @@ _showSdkDocs(event) async {
   Sdk sdk = await findSdk(null);
   if (sdk == null) return;
   // TODO(danrubel) convert Windows file path to URI
-  shell.openExternal('file://${sdk.sdkRootPath}/docs/index.html');
+  var uri = new Uri.file(fs.join(sdk.sdkRootPath, 'docs', 'index.html'));
+  shell.openExternal(uri.toString());
 }

--- a/lib/dartino.dart
+++ b/lib/dartino.dart
@@ -9,9 +9,10 @@ import 'dart:async';
 import 'package:atom/atom.dart';
 import 'package:atom/node/process.dart';
 import 'package:atom/utils/disposable.dart';
-import 'package:atom_dartino/sdk/sdk.dart';
-import 'package:atom_dartino/usb.dart';
 import 'package:logging/logging.dart';
+
+import 'sdk/sdk.dart';
+import 'usb.dart';
 
 export 'package:atom/atom.dart' show registerPackage;
 

--- a/lib/dartino.dart
+++ b/lib/dartino.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:atom/atom.dart';
 import 'package:atom/node/process.dart';
+import 'package:atom/node/shell.dart';
 import 'package:atom/utils/disposable.dart';
 import 'package:logging/logging.dart';
 
@@ -32,6 +33,8 @@ class DartinoDevPackage extends AtomPackage {
     // Register commands.
     _addCmd('atom-workspace', 'dartino:settings', openDartinoSettings);
     _addCmd('atom-workspace', 'dartino:run-app-on-device', _runAppOnDevice);
+    _addCmd('atom-workspace', 'dartino:getting-started', _showGettingStarted);
+    _addCmd('atom-workspace', 'dartino:sdk-docs', _showSdkDocs);
   }
 
   Map config() {
@@ -176,4 +179,15 @@ _runAppOnDevice(event) async {
   if (await sdk.deployAndRun(portName, dstPath)) {
     atom.notifications.addInfo('Launched app on device', dismissable: true);
   }
+}
+
+_showGettingStarted(event) async {
+  shell.openExternal('https://dartino.org/index.html');
+}
+
+_showSdkDocs(event) async {
+  Sdk sdk = await findSdk(null);
+  if (sdk == null) return;
+  // TODO(danrubel) convert Windows file path to URI
+  shell.openExternal('file://${sdk.sdkRootPath}/docs/index.html');
 }

--- a/lib/sdk/dartino_sdk.dart
+++ b/lib/sdk/dartino_sdk.dart
@@ -10,11 +10,11 @@ import 'dart:convert';
 import 'package:atom/atom.dart';
 import 'package:atom/node/fs.dart';
 import 'package:atom/node/process.dart';
-import 'package:atom_dartino/sdk/sdk.dart';
-import 'package:atom_dartino/sdk/sdk_util.dart';
 
 import '../dartino.dart' show pluginId;
-import 'package:atom_dartino/proc.dart';
+import '../proc.dart';
+import 'sdk.dart';
+import 'sdk_util.dart';
 
 class DartinoSdk extends Sdk {
   DartinoSdk(String sdkRootPath) : super(sdkRootPath);

--- a/lib/sdk/dartino_sdk.dart
+++ b/lib/sdk/dartino_sdk.dart
@@ -30,20 +30,21 @@ class DartinoSdk extends Sdk {
             .replaceAll('/', fs.separator);
 
     //TODO(danrubel) show progress while building rather than individual dialogs
-    atom.notifications
+    var info = atom.notifications
         .addInfo('Building application...', detail: srcPath, dismissable: true);
     String stdout = await runProc(buildScript,
         args: [srcPath],
         cwd: srcDir,
         summary: 'building $srcName',
         detail: srcPath);
+    info.dismiss();
     if (stdout == null) return null;
     if (!fs.existsSync(dstPath)) {
       atom.notifications.addError('Failed to build the app',
           dismissable: true, detail: 'Expected build to generate $dstPath');
       return null;
     }
-    atom.notifications.addSuccess('Build successful.', dismissable: true);
+    atom.notifications.addSuccess('Build successful.');
     return dstPath;
   }
 

--- a/lib/sdk/sdk.dart
+++ b/lib/sdk/sdk.dart
@@ -7,10 +7,10 @@ library atom.dartino.sdk;
 import 'dart:async';
 
 import 'package:atom/atom.dart';
-import 'package:atom_dartino/sdk/dartino_sdk.dart';
-import 'package:atom_dartino/sdk/sod_sdk.dart';
 
 import '../dartino.dart' show pluginId, openDartinoSettings;
+import 'dartino_sdk.dart';
+import 'sod_sdk.dart';
 
 /// Return the SDK associated with the given application.
 /// If the SDK cannot be determined, notify the user and return `null`.

--- a/lib/sdk/sod_sdk.dart
+++ b/lib/sdk/sod_sdk.dart
@@ -8,11 +8,12 @@ import 'dart:async';
 
 import 'package:atom/atom.dart';
 import 'package:atom/node/fs.dart';
-import 'package:atom_dartino/dartino.dart' show pluginId;
-import 'package:atom_dartino/proc.dart';
-import 'package:atom_dartino/sdk/sdk.dart';
-import 'package:atom_dartino/sdk/sdk_util.dart';
-import 'package:atom_dartino/usb.dart';
+
+import '../dartino.dart' show pluginId;
+import '../proc.dart';
+import '../usb.dart';
+import 'sdk.dart';
+import 'sdk_util.dart';
 
 class SodSdk extends Sdk {
   SodSdk(String sdkRoot) : super(sdkRoot);

--- a/lib/sdk/sod_sdk.dart
+++ b/lib/sdk/sod_sdk.dart
@@ -25,12 +25,13 @@ class SodSdk extends Sdk {
     String dstPath = srcPath.substring(0, srcPath.length - 5) + '.snap';
 
     //TODO(danrubel) show progress while building rather than individual dialogs
-    atom.notifications
+    var info = atom.notifications
         .addInfo('Building application...', detail: dstPath, dismissable: true);
     String stdout = await runProc('make',
         args: [dstPath], cwd: sdkRootPath, summary: 'build $srcName');
+    info.dismiss();
     if (stdout == null) return null;
-    atom.notifications.addSuccess('Build successful.', dismissable: true);
+    atom.notifications.addSuccess('Build successful.');
     return dstPath;
   }
 

--- a/lib/usb.dart
+++ b/lib/usb.dart
@@ -10,8 +10,9 @@ import 'dart:convert';
 import 'package:atom/atom.dart';
 import 'package:atom/node/fs.dart';
 import 'package:atom/node/process.dart';
-import 'package:atom_dartino/dartino.dart' show pluginId;
 import 'package:logging/logging.dart';
+
+import 'dartino.dart' show pluginId;
 
 /// A map of ttyPath to connected Device
 final Map<String, Device> _devices = {};

--- a/menus/dartino.cson
+++ b/menus/dartino.cson
@@ -8,6 +8,9 @@
           { label: 'Run app on device', command: 'dartino:run-app-on-device' }
           { type: 'separator' }
           { label: 'Package Settings…', command: 'dartino:settings' }
+          { type: 'separator' }
+          { label: 'Getting Started…', command: 'dartino:getting-started' }
+          { label: 'SDK Docs…', command: 'dartino:sdk-docs' }
         ]
       }
     ]


### PR DESCRIPTION
- menu actions to open Getting Started and SDK docs - fixes #15
- auto close/cleanup compile/launch dialogs - fixes #6
- change imports within same lib directory tree to be relative

@devoncarew 
