### PR TITLE
hide toolbar, auto install dartland, and update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dartino plugin changelog
 
+## unreleased
+- hide atom-toolbar on startup (until Dartino launch is integrated in dartlang)
+- auto install dartlang plugin if not already installed
+- updated readme with installation and getting started instructions
+
 ## 0.0.4
 - project folder containing `dartino.yaml` is analyzed as Dartino project
 - auto save editors before running on device

--- a/README.md
+++ b/README.md
@@ -12,15 +12,36 @@ built on top of the Atom [dartlang](https://atom.io/packages/dartlang) plugin.
 - Source code analysis of [SoD](https://github.com/domokit/sod)
 and [Dartino](http://dartino.github.io/sdk/) applications.
 - Single command to compile, deploy, and run code
-on connected device [SoD](https://github.com/domokit/sod) device.
+on connected device.
 
-This is very preliminary Atom plugin... much work and cleanup still to be done.
+## Installation
 
-## Installing
+- Install Atom [atom.io](https://atom.io/)
+- Install this [dartino](https://atom.io/packages/dartino) package
+  (with `apm install dartino` or through the Atom UI)
+- Install [Dart SDK](https://www.dartlang.org/downloads/)
+  version 1.15.0-dev.4.0 or better
+- Install the [Dartino SDK](http://gsdview.appspot.com/dartino-archive/channels/dev/raw/0.3.0-dev.5.2/sdk/)
+  version 0.3.0-dev.5.2 or better
 
-- install Atom [atom.io](https://atom.io/)
-- install this [dartino][] package (with `apm install dartino` or through the
-  Atom UI)
+## Setup in Atom
+
+- Open the dartlang plugin settings page and change
+  the Dart SDK Location to point to your installed Dart SDK
+- Open the dartino plugin settings page and change the Dartino root directory
+  to the location of your installed Dartino SDK
+
+## Quick Start
+
+- Connect computer USB to CN14 USB ST-LINK on STM32 Discovery board
+- Pull down the File menu and select Add Project folder
+- In the dialog that appears, select the dartino-sdk/samples directory
+- In the file tree on the left, select samples/stm32f746g-discovery/lines.dart
+  to open that file
+- Click in the editor
+- To compile, deploy, and run the Dartino application in the active editor
+  on the connected device, either press ctrl-f6
+  or select Packages > Dartino > Run app on device
 
 ## Terms and Privacy
 

--- a/lib/dartino.dart
+++ b/lib/dartino.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:atom/atom.dart';
 import 'package:atom/atom_utils.dart';
+import 'package:atom/utils/package_deps.dart' as package_deps;
 import 'package:atom/node/fs.dart';
 import 'package:atom/node/process.dart';
 import 'package:atom/node/shell.dart';
@@ -31,6 +32,15 @@ class DartinoDevPackage extends AtomPackage {
     _setupLogging();
     _logger.info("activated");
     _logger.fine("Running on Chrome version ${process.chromeVersion}.");
+
+    new Future.delayed(Duration.ZERO, () {
+      package_deps.install('Dartino', this);
+
+      //TODO(danrubel) Remove this once Dartino compile/deploy/run
+      // has been integrated into the base Dart launch manager in dartlang
+      _logger.info('hide atom toolbar');
+      atom.config.setValue('atom-toolbar.visible', false);
+    });
 
     // Register commands.
     _addCmd('atom-workspace', 'dartino:create-new-proj', _createNewProject);


### PR DESCRIPTION
- automatically hide toolbar until Dartino launching is integrated into dartlang - fixes #21 
- automatically install dartlang plugin when dartino plugin is installed - fixes #22 
- update README.md with installation and quick start instructions - fixes #23 

@devoncarew 
